### PR TITLE
fix: proximity wakelock — screen turns on after peer hangup

### DIFF
--- a/client_android/app/src/main/java/com/securecall/app/CallActivity.java
+++ b/client_android/app/src/main/java/com/securecall/app/CallActivity.java
@@ -879,19 +879,17 @@ public class CallActivity extends AppCompatActivity {
             com.securecall.app.ads.AdMobManager.INSTANCE.onCallCompleted(this);
         }
 
-        // Offer to save contact if this was a phone-resolved call to an unsaved clientId
-        // IMPORTANT: Do NOT release proximity sensor before showing dialog — on Samsung devices,
-        // releasing the wake lock triggers a screen state transition that can destroy the Activity.
+        // Release proximity sensor BEFORE dialogs so screen turns on after peer hangup.
+        // FLAG_KEEP_SCREEN_ON prevents Samsung Activity destruction during dialog.
+        releaseProximitySensor();
+
         if (shouldOfferContactSave()) {
-            // Keep screen on while dialog is visible
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             showSaveContactDialog();
         } else if (shouldOfferVerify()) {
-            // BUG-031: Offer to verify unverified contact after call
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             showVerifyDialog();
         } else {
-            releaseProximitySensor();
             finish();
         }
     }


### PR DESCRIPTION
## Summary
Screen stayed off after peer hangup because proximity wakelock was held during post-call dialogs (save contact / verify). Now released before showing dialogs. `FLAG_KEEP_SCREEN_ON` prevents Samsung Activity destruction.

## Test plan
- [x] Build: assemblePremiumDebug + assembleProDebug GREEN
- [ ] S10: Call → hold to ear → peer hangs up → screen should turn on
- [x] S7: APK installed (armeabi-v7a debug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)