### PR TITLE
fix: ringtone as alarm stream + portrait lock during calls

### DIFF
--- a/client_android/app/src/main/AndroidManifest.xml
+++ b/client_android/app/src/main/AndroidManifest.xml
@@ -124,10 +124,12 @@
             android:theme="@style/Theme.AppCompat.NoActionBar" />
         <activity
             android:name=".CallActivity"
-            android:theme="@style/Theme.SecureCall.Call" />
+            android:theme="@style/Theme.SecureCall.Call"
+            android:screenOrientation="portrait" />
         <activity
             android:name=".IncomingCallActivity"
             android:theme="@style/Theme.SecureCall.Call"
+            android:screenOrientation="portrait"
             android:showOnLockScreen="true"
             android:turnScreenOn="true" />
         <activity android:name=".ui.onboarding.OnboardingActivity" />

--- a/client_android/app/src/main/java/com/securecall/app/IncomingCallActivity.kt
+++ b/client_android/app/src/main/java/com/securecall/app/IncomingCallActivity.kt
@@ -345,7 +345,7 @@ class IncomingCallActivity : AppCompatActivity() {
             ringtonePlayer = MediaPlayer().apply {
                 setAudioAttributes(
                     AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                        .setUsage(AudioAttributes.USAGE_ALARM)
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .build()
                 )


### PR DESCRIPTION
## Summary
- Ringtone: `USAGE_ALARM` instead of `USAGE_NOTIFICATION_RINGTONE` — plays at alarm volume, sounds like phone call not message notification
- Rotation: `screenOrientation="portrait"` on CallActivity + IncomingCallActivity — no more flipping during calls

## Test plan
- [x] Build GREEN
- [x] S10 Premium debug installed
- [ ] Incoming call: ringtone sounds like phone call, not notification
- [ ] During call: rotation locked to portrait

🤖 Generated with [Claude Code](https://claude.com/claude-code)