### PR TITLE
fix: proximity sensor + nosensor rotation during calls

### DIFF
--- a/client_android/app/src/main/AndroidManifest.xml
+++ b/client_android/app/src/main/AndroidManifest.xml
@@ -125,11 +125,11 @@
         <activity
             android:name=".CallActivity"
             android:theme="@style/Theme.SecureCall.Call"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="nosensor" />
         <activity
             android:name=".IncomingCallActivity"
             android:theme="@style/Theme.SecureCall.Call"
-            android:screenOrientation="portrait"
+            android:screenOrientation="nosensor"
             android:showOnLockScreen="true"
             android:turnScreenOn="true" />
         <activity android:name=".ui.onboarding.OnboardingActivity" />

--- a/client_android/app/src/main/java/com/securecall/app/CallActivity.java
+++ b/client_android/app/src/main/java/com/securecall/app/CallActivity.java
@@ -128,6 +128,9 @@ public class CallActivity extends AppCompatActivity {
 
         setContentView(R.layout.activity_call);
 
+        // Lock rotation — nosensor ignores accelerometer completely
+        setRequestedOrientation(android.content.pm.ActivityInfo.SCREEN_ORIENTATION_NOSENSOR);
+
         TextView connectionState = findViewById(R.id.connectionState);
         TextView callerNameView = findViewById(R.id.callerName);
         Chronometer callTimer = findViewById(R.id.callTimer);
@@ -575,8 +578,10 @@ public class CallActivity extends AppCompatActivity {
 
     private void releaseProximitySensor() {
         if (proximityWakeLock != null && proximityWakeLock.isHeld()) {
-            proximityWakeLock.release();
-            Log.d(TAG, "Proximity wake lock released");
+            // RELEASE_FLAG_WAIT_FOR_NO_PROXIMITY: screen turns on only when device
+            // is moved away from ear, preventing accidental touch events
+            proximityWakeLock.release(PowerManager.RELEASE_FLAG_WAIT_FOR_NO_PROXIMITY);
+            Log.d(TAG, "Proximity wake lock released (wait for no proximity)");
         }
     }
 


### PR DESCRIPTION
## Summary
- Proximity release: `RELEASE_FLAG_WAIT_FOR_NO_PROXIMITY` — screen waits until device moved from ear
- Rotation: `nosensor` instead of `portrait` — completely ignores accelerometer during call
- Programmatic lock in `CallActivity.onCreate()` as belt-and-suspenders

## Test plan
- [x] Build GREEN
- [x] S10 debug installed
- [ ] Screen off when held to ear during call
- [ ] No rotation at any angle during call

🤖 Generated with [Claude Code](https://claude.com/claude-code)