### PR TITLE
fix: M-02/M-03/M-05 medium findings

### DIFF
--- a/client_android/app/src/main/java/com/securecall/app/net/WebSocketService.kt
+++ b/client_android/app/src/main/java/com/securecall/app/net/WebSocketService.kt
@@ -544,11 +544,12 @@ class WebSocketService : Service(), HeartbeatClient.Listener {
         val phoneNumber = getDevicePhoneNumber()
         // App signature for fork protection — SHA-256 of signing certificate
         val appSignature = getAppSignature()
-        val json = if (phoneNumber != null) {
-            """{"type":"REGISTER","clientId":"$clientId","phoneNumber":"$phoneNumber","appSignature":"$appSignature"}"""
-        } else {
-            """{"type":"REGISTER","clientId":"$clientId","appSignature":"$appSignature"}"""
-        }
+        val json = org.json.JSONObject().apply {
+            put("type", "REGISTER")
+            put("clientId", clientId)
+            if (phoneNumber != null) put("phoneNumber", phoneNumber)
+            put("appSignature", appSignature)
+        }.toString()
         client?.send(json)
         Log.d("WS_SERVICE", "REGISTER sent: $clientId, phone: ${phoneNumber ?: "none"}")
     }

--- a/client_android/app/src/main/java/com/securecall/app/ui/ContactsFragment.kt
+++ b/client_android/app/src/main/java/com/securecall/app/ui/ContactsFragment.kt
@@ -38,6 +38,7 @@ class ContactsFragment : Fragment() {
     private var registeredPhones: Set<String> = emptySet()
     private var onlinePhones: Set<String> = emptySet()
     private var statusRefreshHandler: android.os.Handler? = null
+    private var contactAdapter: ContactAdapter? = null
 
     companion object {
         private const val TAG = "ContactsFragment"
@@ -651,10 +652,16 @@ class ContactsFragment : Fragment() {
         } else {
             recycler.visibility = View.VISIBLE
             emptyState.visibility = View.GONE
-            recycler.adapter = ContactAdapter(contacts, registeredPhones, onlinePhones, cachedOnlineClientIds, isFreeTier(),
-                onCallClick = { contact -> startCall(contact) },
-                onLongClick = { contact -> showContactMenu(contact) }
-            )
+            val existing = contactAdapter
+            if (existing != null && recycler.adapter === existing) {
+                existing.updateData(contacts, registeredPhones, onlinePhones, cachedOnlineClientIds, isFreeTier())
+            } else {
+                contactAdapter = ContactAdapter(contacts, registeredPhones, onlinePhones, cachedOnlineClientIds, isFreeTier(),
+                    onCallClick = { contact -> startCall(contact) },
+                    onLongClick = { contact -> showContactMenu(contact) }
+                )
+                recycler.adapter = contactAdapter
+            }
         }
     }
 

--- a/client_android/app/src/main/java/com/securecall/app/ui/DialerFragment.kt
+++ b/client_android/app/src/main/java/com/securecall/app/ui/DialerFragment.kt
@@ -331,6 +331,7 @@ class DialerFragment : Fragment() {
     }
 
     private fun showInviteDialog(number: String) {
+        if (!isAdded) return
         val items = arrayOf(
             getString(R.string.dialer_send_messenger),
             getString(R.string.dialer_share_link),
@@ -370,6 +371,7 @@ class DialerFragment : Fragment() {
     }
 
     private fun sendViaMessenger(number: String) {
+        if (!isAdded) return
         val message = buildInviteMessage()
         // Try messengers in priority order: WhatsApp > Telegram > Signal
         val messengers = listOf(
@@ -399,6 +401,7 @@ class DialerFragment : Fragment() {
     }
 
     private fun sendSmsInvite(number: String) {
+        if (!isAdded) return
         val message = buildInviteMessage()
         try {
             val intent = Intent(Intent.ACTION_SENDTO).apply {
@@ -412,6 +415,7 @@ class DialerFragment : Fragment() {
     }
 
     private fun shareInviteLink() {
+        if (!isAdded) return
         val message = buildInviteMessage()
         val intent = Intent(Intent.ACTION_SEND).apply {
             type = "text/plain"

--- a/client_android/app/src/main/java/com/securecall/app/ui/adapter/ContactAdapter.kt
+++ b/client_android/app/src/main/java/com/securecall/app/ui/adapter/ContactAdapter.kt
@@ -11,14 +11,29 @@ import com.securecall.app.R
 import com.securecall.app.data.Contact
 
 class ContactAdapter(
-    private val contacts: List<Contact>,
-    private val registeredPhones: Set<String> = emptySet(),
-    private val onlinePhones: Set<String> = emptySet(),
-    private val onlineClientIds: Set<String> = emptySet(),
-    private val hideOnlineStatus: Boolean = false,
+    private var contacts: List<Contact>,
+    private var registeredPhones: Set<String> = emptySet(),
+    private var onlinePhones: Set<String> = emptySet(),
+    private var onlineClientIds: Set<String> = emptySet(),
+    private var hideOnlineStatus: Boolean = false,
     private val onCallClick: ((Contact) -> Unit)? = null,
     private val onLongClick: ((Contact) -> Unit)? = null
 ) : RecyclerView.Adapter<ContactAdapter.ViewHolder>() {
+
+    fun updateData(
+        newContacts: List<Contact>,
+        newRegistered: Set<String>,
+        newOnline: Set<String>,
+        newOnlineClientIds: Set<String>,
+        newHideOnlineStatus: Boolean
+    ) {
+        contacts = newContacts
+        registeredPhones = newRegistered
+        onlinePhones = newOnline
+        onlineClientIds = newOnlineClientIds
+        hideOnlineStatus = newHideOnlineStatus
+        notifyDataSetChanged()
+    }
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val txtAvatar: TextView = view.findViewById(R.id.txtAvatar)


### PR DESCRIPTION
## Summary
- **M-02**: Replace JSON string interpolation with `JSONObject` in REGISTER message — prevents JSON breakage from special chars in clientId/phoneNumber
- **M-03**: Add `isAdded` guards to DialerFragment dialog callback functions — prevents `IllegalStateException` if fragment detaches while dialog is open
- **M-05**: Reuse `ContactAdapter` instance via new `updateData()` method instead of creating new adapter on every 15s refresh — preserves scroll position

## Test plan
- [ ] Verify REGISTER message is valid JSON with special chars in SecureID
- [ ] Verify invite dialog works after rapid fragment switching
- [ ] Verify contacts list scroll position preserved across 15s refresh cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)