### PR TITLE
fix: LOW findings BUG-075/076/077/079/080

### DIFF
--- a/backend/signaling/src/server.js
+++ b/backend/signaling/src/server.js
@@ -407,7 +407,8 @@ function requireAdmin(req, res, next) {
   if (!ADMIN_API_KEY) {
     return res.status(403).json({ error: "admin_api_disabled" });
   }
-  const provided = req.headers["x-admin-key"] || req.query.admin_key;
+  // BUG-076: Only accept admin key via header, not query param (prevents log leak)
+  const provided = req.headers["x-admin-key"];
   if (provided !== ADMIN_API_KEY) {
     return res.status(401).json({ error: "unauthorized" });
   }
@@ -750,7 +751,7 @@ wss.on("connection", (ws, req) => {
         phoneNumbers.set(phone, msg.clientId);
         phoneHashes.set(hashPhone(phone), msg.clientId);
         client.phoneNumber = phone;
-        console.log("[REGISTER] Phone:", phone, "->", msg.clientId);
+        console.log("[REGISTER] Phone:", hashPhone(phone), "->", msg.clientId);
       }
 
       console.log("[REGISTER]", msg.clientId, "->", connId);
@@ -795,7 +796,7 @@ wss.on("connection", (ws, req) => {
           // Try phone number lookup
           const phoneLookup = phoneNumbers.get(normalizePhone(targetClientId));
           if (phoneLookup) {
-            console.log("[ROUTING] Phone resolved:", targetClientId, "->", phoneLookup);
+            console.log("[ROUTING] Phone resolved: hash", hashPhone(targetClientId), "->", phoneLookup);
             targetClientId = phoneLookup;
           }
         }
@@ -1518,7 +1519,7 @@ wss.on("connection", (ws, req) => {
           if (cid === myClientId) {
             phoneNumbers.delete(phone);
             phoneHashes.delete(hashPhone(phone));
-            console.log("[DEREGISTER] Removed phone mapping:", phone, "->", myClientId);
+            console.log("[DEREGISTER] Removed phone mapping:", hashPhone(phone), "->", myClientId);
             break;
           }
         }
@@ -1761,10 +1762,11 @@ app.delete("/admin/gift/:code", requireAdmin, (req, res) => {
 });
 
 // --- Invite System ---
+// BUG-077: Don't reveal whether a SecureID exists (user enumeration).
+// Always return the same response regardless of existence.
 app.get("/invite/:secureId", (req, res) => {
-  const secureId = req.params.secureId;
-  const exists = clientIds.has(secureId);
-  res.json({ secureId, exists, online: exists });
+  const secureId = sanitize(req.params.secureId);
+  res.json({ secureId, ok: true });
 });
 
 app.post("/invite/accepted", (req, res) => {
@@ -2097,8 +2099,19 @@ server.listen(PORT, "0.0.0.0", () => {
 // --- Graceful Shutdown ---
 process.on('SIGTERM', () => {
   console.log('[SIGNAL] SIGTERM received, shutting down gracefully');
+  // BUG-080: Close all WebSocket connections before shutting down
+  for (const [connId, client] of clients) {
+    try {
+      client.ws.close(1001, "Server shutting down");
+    } catch (e) {}
+  }
   server.close(() => {
     console.log('[SIGNAL] Server closed');
     process.exit(0);
   });
+  // Force exit after 10s if connections don't close cleanly
+  setTimeout(() => {
+    console.warn('[SIGNAL] Forcing exit after timeout');
+    process.exit(1);
+  }, 10000);
 });

--- a/client_android/app/src/main/java/com/securecall/app/data/ContactRepository.kt
+++ b/client_android/app/src/main/java/com/securecall/app/data/ContactRepository.kt
@@ -101,10 +101,10 @@ object ContactRepository {
             .edit().putStringSet(KEY_HIDDEN, hidden).apply()
     }
 
-    /** Returns set of normalized phone numbers that the user has dismissed. */
+    /** Returns defensive copy of normalized phone numbers that the user has dismissed. */
     fun getHiddenPhones(context: Context): Set<String> {
         return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .getStringSet(KEY_HIDDEN, emptySet()) ?: emptySet()
+            .getStringSet(KEY_HIDDEN, emptySet())?.toSet() ?: emptySet()
     }
 
     private fun persist(context: Context, contacts: List<Contact>) {


### PR DESCRIPTION
## Summary
- **BUG-075**: Hash phone numbers in server logs instead of raw PII
- **BUG-076**: Admin key header-only — removed `req.query.admin_key` (prevents URL/access log leak)
- **BUG-077**: `/invite/:secureId` no longer reveals user existence (anti-enumeration)
- **BUG-079**: `getHiddenPhones()` returns `.toSet()` defensive copy
- **BUG-080**: Graceful shutdown closes all WS connections + 10s force-exit timeout

BUG-078 deferred: phone normalization inconsistency (15+ DCARS sites in ContactsFragment)

## Test plan
- [ ] Server logs show hashed phones, not raw numbers
- [ ] Admin endpoints reject `?admin_key=...` query param
- [ ] `/invite/nonexistent-id` returns `{ok: true}` (no existence leak)
- [ ] App restart: hiddenPhones set not accidentally mutated
- [ ] SIGTERM: WS clients receive close(1001) before server exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)