### PR TITLE
feat: battery optimization setting + play store signing key

### DIFF
--- a/client_android/app/src/main/java/com/securecall/app/ui/SettingsFragment.kt
+++ b/client_android/app/src/main/java/com/securecall/app/ui/SettingsFragment.kt
@@ -74,6 +74,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
             true
         }
 
+        // Battery optimization status + toggle
+        configureBatteryOptimization()
+
         // Upgrade button — hidden for Premium, shows "Upgrade to Premium" for Pro
         findPreference<Preference>("pref_upgrade")?.apply {
             when (effectiveTier) {
@@ -374,6 +377,42 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
         findPreference<Preference>("pref_donate_ifr")?.setOnPreferenceClickListener {
             openUrl("https://ifrunit.tech")
+            true
+        }
+    }
+
+    @android.annotation.SuppressLint("BatteryLife")
+    private fun configureBatteryOptimization() {
+        val pref = findPreference<Preference>("pref_battery_optimization") ?: return
+        val ctx = context ?: return
+        val pm = ctx.getSystemService(android.os.PowerManager::class.java) ?: return
+        val isIgnoring = pm.isIgnoringBatteryOptimizations(ctx.packageName)
+
+        if (isIgnoring) {
+            pref.summary = "✅ Unrestricted — connection stays alive"
+        } else {
+            pref.summary = "⚠️ Restricted — may lose connection in background"
+        }
+
+        pref.setOnPreferenceClickListener {
+            if (isIgnoring) {
+                android.widget.Toast.makeText(ctx, "Already unrestricted", android.widget.Toast.LENGTH_SHORT).show()
+            } else {
+                try {
+                    val intent = android.content.Intent(
+                        android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                        android.net.Uri.parse("package:${ctx.packageName}")
+                    )
+                    startActivity(intent)
+                } catch (e: Exception) {
+                    // Fallback: open app details
+                    try {
+                        val intent = android.content.Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                        intent.data = android.net.Uri.parse("package:${ctx.packageName}")
+                        startActivity(intent)
+                    } catch (_: Exception) {}
+                }
+            }
             true
         }
     }

--- a/client_android/app/src/main/res/xml/preferences.xml
+++ b/client_android/app/src/main/res/xml/preferences.xml
@@ -141,6 +141,11 @@
             android:summary="@string/pref_background_service_summary"
             android:defaultValue="true"
             android:icon="@drawable/ic_shield" />
+        <Preference
+            android:key="pref_battery_optimization"
+            android:title="Battery Optimization"
+            android:summary="Disable to keep connection alive"
+            android:icon="@drawable/ic_shield" />
         <SwitchPreferenceCompat
             android:key="pref_call_history"
             android:title="@string/pref_call_history"


### PR DESCRIPTION
## Summary
- **Battery Optimization:** New preference in Calls section showing ✅/⚠️ status. Tap opens system battery settings for exemption. Fixes Samsung A-series background kills.
- **Play Store Key:** `ALLOWED_SIGNATURES` on Railway updated to include Google Play App Signing Key (`2a84ede5...`) alongside release upload key (`1e0a8eb4...`).

## Test plan
- [ ] Settings → Calls → Battery Optimization shows correct status
- [ ] Tap opens system battery exemption dialog
- [ ] Play Store installed clients can now connect (no more REJECTED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)